### PR TITLE
syncEntity from getSDK fixed + VisibilityComponent synced

### DIFF
--- a/src/ui/counter.ts
+++ b/src/ui/counter.ts
@@ -1,6 +1,5 @@
 import { Entity, TransformTypeWithOptionals } from '@dcl/sdk/ecs'
 import { Vector3 } from '@dcl/sdk/math'
-import { syncEntity } from '@dcl/sdk/network'
 import { getSDK } from '../sdk'
 
 type justification = 'left' | 'right' | 'center'
@@ -61,6 +60,7 @@ export class Counter3D {
   addDigits() {
     const {
       engine,
+      syncEntity,
       components: { Transform, GltfContainer, VisibilityComponent }
     } = getSDK()
     for (let i = 0; i < this.maxDigits; i++) {
@@ -72,7 +72,11 @@ export class Counter3D {
       VisibilityComponent.createOrReplace(numberEntity)
       this.digits.push(numberEntity)
 
-      syncEntity(numberEntity, [Transform.componentId, GltfContainer.componentId], this.id * 20000 + i)
+      syncEntity(
+        numberEntity,
+        [Transform.componentId, GltfContainer.componentId, VisibilityComponent.componentId],
+        this.id * 20000 + i
+      )
     }
   }
 


### PR DESCRIPTION
- Counter3D had a syncEntity that was coming from a separate engine, fixed this to be coming from the scene's engine (with getSDK)
- added VisibilityComponent of the counter digits to the synced components